### PR TITLE
docs: Updated docs theme and other metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,14 @@ Thumbs.db
 # Environment / secrets
 .env
 .env.*
+
+# Jekyll build output
+docs/_site/
+
+# Bundler
+docs/.bundle/
+docs/Gemfile.lock
+
+# Ruby
+*.gem
+*.rbc

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,28 @@
 # Configuration
 # =============================================================================
 
-UV              := uv
-UV_RUN          := uv run
-PACKAGE_NAME    := create-agentverse-agent
+UV           := uv
+UV_RUN       := uv run
+PACKAGE_NAME := create-agentverse-agent
 
-PYTEST_ARGS     := tests/ -v --cov=. --cov-report=term-missing
-RUFF_ARGS       := .
-BLACK_ARGS      := .
-TY_ARGS         := .
+PYTEST_ARGS  := tests/ -v --cov=. --cov-report=term-missing
+RUFF_ARGS    := .
+BLACK_ARGS   := .
+TY_ARGS      := .
+
+DOCS_DIR     := docs
 
 # =============================================================================
 # Phony targets
 # =============================================================================
 
 .PHONY: help \
-        install install-dev reinstall \
-        lint lint-fix format typecheck test check \
-        clean clean-caches clean-build \
-        pre-commit pre-commit-install
+	install install-dev reinstall \
+	lint lint-fix format typecheck test check \
+	clean clean-caches clean-build \
+	pre-commit pre-commit-install \
+	build watch-typecheck dev \
+	docs-install docs-dev docs-clean docs-reinstall docs-check
 
 # =============================================================================
 # Help
@@ -44,10 +48,20 @@ help:
 	@echo "  check              Run full quality pipeline (lint-fix + format + typecheck + test)"
 	@echo "  pre-commit         Run pre-commit on all files"
 	@echo ""
+	@echo "Build:"
+	@echo "  build              Build package (runs check first)"
+	@echo ""
 	@echo "Maintenance:"
 	@echo "  clean              Remove all caches and build artifacts"
 	@echo "  clean-caches       Remove only cache directories"
 	@echo "  clean-build        Remove only build artifacts"
+	@echo ""
+	@echo "Docs:"
+	@echo "  docs-install       Install docs dependencies"
+	@echo "  docs-dev           Start docs dev server"
+	@echo "  docs-check         Build docs (no server)"
+	@echo "  docs-clean         Clean docs build artifacts"
+	@echo "  docs-reinstall     Clean and reinstall docs environment"
 	@echo ""
 
 # =============================================================================
@@ -141,3 +155,29 @@ dev: install-dev pre-commit-install
 	@echo ""
 	@echo "Run 'make check' to verify your setup"
 	@echo ""
+
+# =============================================================================
+# Docs (Jekyll / GitHub Pages)
+# =============================================================================
+
+docs-install:
+	@echo "📚 Installing docs dependencies..."
+	@cd $(DOCS_DIR) && bundle install
+
+docs-dev:
+	@echo "🚀 Starting docs dev server..."
+	@echo "➡️  http://localhost:4000"
+	@cd $(DOCS_DIR) && bundle exec jekyll serve
+
+docs-check:
+	@echo "🔍 Building docs (no server)..."
+	@cd $(DOCS_DIR) && bundle exec jekyll build
+
+docs-clean:
+	@echo "🧹 Cleaning docs build artifacts..."
+	@rm -rf $(DOCS_DIR)/_site
+	@rm -rf $(DOCS_DIR)/.bundle
+	@rm -f $(DOCS_DIR)/Gemfile.lock
+
+docs-reinstall: docs-clean docs-install
+	@echo "🔄 Docs environment reinstalled."

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,16 +1,81 @@
-theme: jekyll-theme-minimal
+# ================================
+# Core site settings
+# ================================
+remote_theme: just-the-docs/just-the-docs
 
 title: create-agentverse-agent
 description: A CLI tool to scaffold production-ready uAgents with best practices baked in
+url: https://create-agentverse-agent.tech
+favicon_ico: "/assets/images/favicon.svg"
 
 repository: tejus3131/create-agentverse-agent
+
 author:
   name: Tejus Gupta
   url: https://tejusgupta.dev
   email: hello@tejusgupta.dev
 
+
+# ================================
+# Plugins (GitHub Pages safe)
+# ================================
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-default-layout
+  - jekyll-titles-from-headings
+
+
+# ================================
+# Markdown & syntax highlighting
+# ================================
 markdown: kramdown
 
+kramdown:
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    css_class: highlight
+    line_numbers: false
+    block_html: true
+
+
+# ================================
+# Just-the-Docs settings
+# ================================
+search_enabled: true
+
+search:
+  heading_level: 2
+  previews: 3
+  preview_words_before: 6
+  preview_words_after: 10
+  tokenizer_separator: /[\s/]+/
+
+
+# Navigation & UX
+heading_anchors: true
+back_to_top: true
+
+
+# ================================
+# Theme / Appearance
+# ================================
+color_scheme: light
+enable_copy_code_button: true
+
+
+# ================================
+# SEO
+# ================================
+seo:
+  type: SoftwareSourceCode
+  name: create-agentverse-agent
+
+
+# ================================
+# Excludes
+# ================================
 exclude:
   - .github/
   - src/

--- a/docs/assets/images/favicon.svg
+++ b/docs/assets/images/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1e1e2e"/>
+  <text
+    x="50%"
+    y="55%"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-family="JetBrains Mono, SFMono-Regular, Menlo, monospace"
+    font-size="16"
+    fill="#cdd6f4"
+  >&gt;_</text>
+</svg>

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -49,7 +49,7 @@ The application entrypoint that:
 
 Environment variables for configuration:
 
-```env
+```bash
 # Environment Configuration
 ENV=
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage = "https://create-agentverse-agent.tech/"
 Repository = "https://github.com/tejus3131/create-agentverse-agent"
 Issues = "https://github.com/tejus3131/create-agentverse-agent/issues"
 Documentation = "https://create-agentverse-agent.tech/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/tejus3131/create-agentverse-agent"
 Repository = "https://github.com/tejus3131/create-agentverse-agent"
 Issues = "https://github.com/tejus3131/create-agentverse-agent/issues"
-Documentation = "https://github.com/tejus3131/create-agentverse-agent#readme"
+Documentation = "https://create-agentverse-agent.tech/"
 Changelog = "https://github.com/tejus3131/create-agentverse-agent/releases"
 
 [project.scripts]


### PR DESCRIPTION
This pull request adds a full documentation workflow using Jekyll and the Just-the-Docs theme, and integrates it into the project’s `Makefile` for easy management. It also updates documentation URLs to point to the new documentation site.

Documentation infrastructure and workflow:

* Added a `docs` directory with a `Gemfile` specifying the `github-pages` gem for Jekyll-based documentation.
* Created a comprehensive `docs/_config.yml` to configure the Just-the-Docs theme, plugins, search, SEO, and site appearance for the documentation site.
* Updated the Makefile to add targets for installing, building, serving, cleaning, and reinstalling documentation, as well as grouped help messages for these new commands. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R14-R15) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L22-R26) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R51-R65) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R158-R183)

Documentation and metadata updates:

* Updated the documentation URL in `pyproject.toml` to point to the new documentation site at https://create-agentverse-agent.tech/.
* Minor improvement to code block language in `docs/structure.md` for better syntax highlighting.