### PR TITLE
chore(CI): Restrict CI workflow to main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration. The change restricts the workflow to run only on the `main` branch, instead of both `main` and `develop`.